### PR TITLE
이시국에지금 채널 추가

### DIFF
--- a/main_yt.js
+++ b/main_yt.js
@@ -22,7 +22,8 @@ const cancerList = [
   "페페TV • 조회수1234만회",
   "팩튜브",
   "단골이슈",
-  "뉴스팩트럼"
+  "뉴스팩트럼",
+  "이시국에지금"
 ]
 
 document.querySelectorAll('.ytd-channel-name').forEach((el) => {


### PR DESCRIPTION
`이시국에지금` 채널이 국뽕채널이라고 판단하여 검열 리스트에 추가합니다.

https://www.youtube.com/channel/UCEkRaSQww-uFbUUpaSq5JZw

![image](https://user-images.githubusercontent.com/30339539/146918293-cac7176f-29fb-4adf-810f-d5e07e32f6bd.png)
사진과 같이 영상 제목이 모두 `안녕하세요.`라고 되어있는 것과 썸네일, 영상 등을 봤을 때 국뽕채널로 판단됩니다.